### PR TITLE
Bug | "About Us Item Info" doesn't have title

### DIFF
--- a/sanity/schemas/objects/global/buttonType.ts
+++ b/sanity/schemas/objects/global/buttonType.ts
@@ -32,7 +32,6 @@ export const buttonType = defineField({
                     { title: "No link", value: "noLink" },
                     { title: "Internal", value: "internal" },
                     { title: "External", value: "external" },
-                    { title: "Internal Site Page Link", value: "pageBuilder" },
                 ],
             },
             initialValue: "noLink",

--- a/sanity/schemas/objects/module/aboutUsHomeType.ts
+++ b/sanity/schemas/objects/module/aboutUsHomeType.ts
@@ -17,8 +17,9 @@ export const aboutUsItemType = defineField({
     ],
     preview: {
         select: {
-            title: "About us",
+            title: "AboutUs",
         },
+
         prepare({ title }) {
             const englishTitle = getEnglishTitleFromIntArrays(title);
             return {

--- a/sanity/schemas/objects/module/aboutUsHomeType.ts
+++ b/sanity/schemas/objects/module/aboutUsHomeType.ts
@@ -9,7 +9,7 @@ export const aboutUsItemType = defineField({
     type: "object",
     fields: [
         defineField({
-            name: "AboutUs",
+            name: "aboutUs",
             description: "About us item information",
             type: "internationalizedArrayString",
             title: "About us Item",
@@ -17,7 +17,7 @@ export const aboutUsItemType = defineField({
     ],
     preview: {
         select: {
-            title: "AboutUs",
+            title: "aboutUs",
         },
 
         prepare({ title }) {


### PR DESCRIPTION
update button + update titles 
<img width="646" alt="image" src="https://github.com/user-attachments/assets/a7ff2310-a340-48d6-9ab7-9765fa058d4b">
